### PR TITLE
fixed EthernetTab url in plugins.qmltypes

### DIFF
--- a/networksettings_module/plugins.qmltypes
+++ b/networksettings_module/plugins.qmltypes
@@ -17,7 +17,7 @@ Module {
     }
     Component {
         name: "EthernetTab"
-        exports: ["networksettings/WifiTab 1.0"]
+        exports: ["networksettings/EthernetTab 1.0"]
 	prototype: "QObject"
 
         Property { name: "fontPixelSize"; type: "int"; isReadonly: false } 


### PR DESCRIPTION
Signed-off-by: bhamacher <b.hamacher@zera.de>

WifiTab and EthernetTab had the same url. This is of course not working out for qtCreator.