### PR TITLE
Give up ZCC.standardMargin

### DIFF
--- a/libs/zeracomponents_lib/src/qml/ZButton.qml
+++ b/libs/zeracomponents_lib/src/qml/ZButton.qml
@@ -8,7 +8,7 @@ Button {
 
   // Button has special ideas - force our margins
   background.anchors.fill: root
-  background.anchors.topMargin: ZCC.standardMargin
-  background.anchors.bottomMargin: ZCC.standardMargin
-  background.anchors.rightMargin: ZCC.standardMargin
+  background.anchors.topMargin: 0
+  background.anchors.bottomMargin: 0
+  background.anchors.rightMargin: 0
 }

--- a/libs/zeracomponents_lib/src/qml/ZLineEdit.qml
+++ b/libs/zeracomponents_lib/src/qml/ZLineEdit.qml
@@ -86,14 +86,12 @@ Item {
     verticalAlignment: Text.AlignVCenter
     font.pointSize: root.pointSize
     anchors.left: parent.left
-    anchors.rightMargin: text !== "" ? ZCC.standardMargin : 0
   }
   Item {
     anchors.left: descriptionText.right
     anchors.top: parent.top
     anchors.bottom: parent.bottom
     anchors.right: unitLabel.left
-    anchors.rightMargin: unitLabel.text !== "" ? ZCC.standardMargin : 0
 
     TextField {
       id: tField
@@ -166,7 +164,6 @@ Item {
     height: parent.height
     font.pointSize: root.pointSize
     anchors.right: parent.right
-    anchors.rightMargin: text !== "" ? ZCC.standardMargin : 0
     verticalAlignment: Text.AlignVCenter
   }
 }

--- a/libs/zeracomponents_lib/src/qml/ZeraComponentsConfig.qml
+++ b/libs/zeracomponents_lib/src/qml/ZeraComponentsConfig.qml
@@ -7,7 +7,6 @@ import ZeraLocale 1.0
 //
 Item {
     // margin properties
-    property real standardMargin: 0
     property real standardTextHorizMargin: 8
     property real standardTextBottomMargin: 8
 }


### PR DESCRIPTION
I was the one who introduced it and played around it in the beginning to
find out that a value of 0 (which is default for most controls except
buttons - see ZButton) is fine.

* This is just a small step to get ZLineEdit work on within layouts
* a follow-up patch for vf-declarative-gui is in the queue

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>