### PR TITLE
zeraFa: split icon() into colorize() + icon()

### DIFF
--- a/libs/zeraFa/src/qml/ZeraFa514.qml
+++ b/libs/zeraFa/src/qml/ZeraFa514.qml
@@ -28,14 +28,21 @@ Item {
         id: variables
     }
 
-    function icon(symbols, color) {
-        var colorStart="";
-        var colorEnd="";
-        if(color!=null) //implicit conversion is intentional
-        {
-            colorStart="<font color='"+color+"'>";
-            colorEnd="</font>";
+    // Tiny helper for colored glyphs
+    function colorize(glyph, color) {
+        var colorStart = "";
+        var colorEnd = "";
+        if(color !== "") {
+            colorStart = "<font color='" + color + "'>";
+            colorEnd = "</font>";
         }
-        return colorStart+symbols+" "+colorEnd;
+        return colorStart + glyph + colorEnd;
+    }
+
+    // Tiny helper just appending a space after glyph
+    // just for sake of compatibility - suggested usage:
+    // text: icon(glyph, color) + "your text"
+    function icon(glyph, color) {
+        return colorize(glyph + " ", color)
     }
 }

--- a/libs/zeraFa/src/qml/ZeraFaOld.qml
+++ b/libs/zeraFa/src/qml/ZeraFaOld.qml
@@ -5,16 +5,22 @@ import QtQuick.Controls 2.0
 
 Item {
     id: zerafa
-    //a wrapper that allows easy coloring and adds a space at the end
-    function icon(symbols, color) {
-        var colorStart="";
-        var colorEnd="";
-        if(color!=null) //implicit conversion is intentional
-        {
-            colorStart="<font color='"+color+"'>";
-            colorEnd="</font>";
+    // Tiny helper for colored glyphs
+    function colorize(glyph, color) {
+        var colorStart = "";
+        var colorEnd = "";
+        if(color !== "") {
+            colorStart = "<font color='" + color + "'>";
+            colorEnd = "</font>";
         }
-        return colorStart+symbols+" "+colorEnd;
+        return colorStart + glyph + colorEnd;
+    }
+
+    // Tiny helper just appending a space after glyph
+    // just for sake of compatibility - suggested usage:
+    // text: icon(glyph, color) + "your text"
+    function icon(glyph, color) {
+        return colorize(glyph + " ", color)
     }
 
     readonly property FontLoader fontAwesomeOld: FontLoader {


### PR DESCRIPTION
The function icon() does two things at one time: colorize glyph and append
space for a margin. There are cases we just want colored glyphs so introduce
colorize().

This was stolen from fontawesome-qml [1] and in the long run we should replace
zerafa by fontawesome-qml (as discussed) but now is not the time...

[1] https://github.com/schnitzeltony/fontawesome-qml

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>