### PR TITLE
zeraFa: The last changes in vf-dec-gui would not mix Fontawesome and …

### DIFF
--- a/libs/zeraFa/src/qml/ZeraFa514.qml
+++ b/libs/zeraFa/src/qml/ZeraFa514.qml
@@ -10,9 +10,11 @@ Item {
     property alias icons: variables
 
     readonly property FontLoader fontAwesomeRegular: FontLoader {
+        name: "FARegular"
         source: "qrc:/3rdParty/Font-Awesome/webfonts/fa-regular-400.ttf"
     }
     readonly property FontLoader fontAwesomeSolid: FontLoader {
+        name: "FASolid"
         source: "qrc:/3rdParty/Font-Awesome/webfonts/fa-solid-900.ttf"
     }
     readonly property FontLoader fontAwesomeBrands: FontLoader {

--- a/libs/zeraFa/src/qml/ZeraFaOld.qml
+++ b/libs/zeraFa/src/qml/ZeraFaOld.qml
@@ -24,6 +24,7 @@ Item {
     }
 
     readonly property FontLoader fontAwesomeOld: FontLoader {
+        name: "FAOld"
         source: "qrc:/3rdParty/Font-Awesome_Old/fontawesome-webfont.ttf"
     }
 


### PR DESCRIPTION
…text properly.

The problem got solved by adding names to the different font types.
I think the problem was always there
but occurred only now because of the latest changes.

Signed-off-by: bhamacher <b.hamacher@zera.de>