### PR TITLE
ZComboBox: Do not colorize arrow down

### DIFF
--- a/libs/zeracomponents_lib/src/qml/ZeraComponents/ZComboBox.qml
+++ b/libs/zeracomponents_lib/src/qml/ZeraComponents/ZComboBox.qml
@@ -116,7 +116,6 @@ Rectangle {
         text: "▼"
         textFormat: Text.PlainText
         font.pixelSize: root.fontSize/2
-        color: textColor
     }
 
     MouseArea {


### PR DESCRIPTION
Otherwise our users do not recognize the combobox properly

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>