### PR TITLE
ZComboBox: Do not close on model change

### DIFF
--- a/libs/zeracomponents_lib/src/qml/ZeraComponents/ZComboBox.qml
+++ b/libs/zeracomponents_lib/src/qml/ZeraComponents/ZComboBox.qml
@@ -84,7 +84,6 @@ Rectangle {
         if(model) {
             updateFakeModel();
         }
-        selectionDialog.close()
     }
 
     // List view does not support JS arrays


### PR DESCRIPTION
There is no single reason to close and it annoyed during clamp mount/unmount
tests.

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>